### PR TITLE
Add SNS screenshot into gallery after captured

### DIFF
--- a/src/main/kotlin/com/gh0u1l5/wechatmagician/backend/WechatEvents.kt
+++ b/src/main/kotlin/com/gh0u1l5/wechatmagician/backend/WechatEvents.kt
@@ -114,6 +114,7 @@ object WechatEvents {
                 val path = "$storage/screenshot/$filename"
                 val bitmap = ViewUtil.drawView(layout)
                 FileUtil.writeBitmapToDisk(path, bitmap)
+                FileUtil.galleryAddPic(path, layout.context)
                 Toast.makeText(
                         layout.context, str["prompt_screenshot"] + path, Toast.LENGTH_SHORT
                 ).show()

--- a/src/main/kotlin/com/gh0u1l5/wechatmagician/util/FileUtil.kt
+++ b/src/main/kotlin/com/gh0u1l5/wechatmagician/util/FileUtil.kt
@@ -1,6 +1,9 @@
 package com.gh0u1l5.wechatmagician.util
 
+import android.content.Intent
+import android.content.Context
 import android.graphics.Bitmap
+import android.net.Uri
 import android.os.SystemClock.elapsedRealtime
 import java.io.*
 import java.lang.System.currentTimeMillis
@@ -69,5 +72,13 @@ object FileUtil {
         if (modifiedAt < bootAt) {
             writeCallback(path)
         }
+    }
+
+    fun galleryAddPic(path: String, context: Context) {
+        val mediaScanIntent = Intent(Intent.ACTION_MEDIA_SCANNER_SCAN_FILE)
+        val f = File(path)
+        val contentUri = Uri.fromFile(f)
+        mediaScanIntent.data = contentUri
+        context.sendBroadcast(mediaScanIntent)
     }
 }


### PR DESCRIPTION
Cannot found the SNS screenshot in Gallery application (nor in WeChat's image selection view) on my device (ROM AospExtented 4.6 for OnePlus2, API 25). 
Refering to https://developer.android.com/training/camera/photobasics.html#TaskGallery , need to invoke the system's media scanner to add this photo to the Media Provider's database, making it available in the Android Gallery application and to other apps.
Tested on my device, worked well. 